### PR TITLE
Update verticalMetricsProof.py

### DIFF
--- a/verticalMetricsProof.py
+++ b/verticalMetricsProof.py
@@ -171,7 +171,7 @@ def draw_metrics_page(f_info, page_width=5000):
     scale_factor = PT_SIZE / upm
     x_offset = MARGIN_L / scale_factor
     font_height = f_info.winAscent + f_info.winDescent
-    page_height = font_height * 1.33 * scale_factor
+    page_height = font_height * 1.4 * scale_factor
     db.newPage(page_width, page_height)
     baseline = db.height() / 3 / scale_factor
 


### PR DESCRIPTION
Quick-and-dirty fix to give winAscent/sTypoAscender/hhea.ascent labels a bit more breathing room at the top. At some point we should figure out a reliable calculation that takes overall (actual) tont height, label position, etc. into account so everything fits for every case.