### PR TITLE
fixes to verticalMetrics proofs

### DIFF
--- a/figureSpacingProofUFO.py
+++ b/figureSpacingProofUFO.py
@@ -21,17 +21,11 @@ import subprocess
 import drawBot as db
 
 from fontParts.fontshell import RFont
-from fontTools.pens.cocoaPen import CocoaPen
 
+from proofing_helpers.drawing import draw_glyph
 from proofing_helpers.files import get_ufo_paths
 from proofing_helpers.globals import FONT_MONO
 from proofing_helpers.stamps import timestamp
-
-
-def draw_glyph(glyph):
-    cpen = CocoaPen(glyph.getParent())
-    glyph.draw(cpen)
-    db.drawPath(cpen.path)
 
 
 def joinit(iterable, delimiter):

--- a/glyphProofUFO.py
+++ b/glyphProofUFO.py
@@ -27,9 +27,8 @@ import subprocess
 import defcon
 import drawBot as db
 
-from fontTools.pens.cocoaPen import CocoaPen
-
 from proofing_helpers import fontSorter
+from proofing_helpers.drawing import draw_glyph
 from proofing_helpers.files import get_ufo_paths
 from proofing_helpers.globals import FONT_MONO
 from proofing_helpers.stamps import timestamp
@@ -99,12 +98,6 @@ def get_options(args=None):
         help='folder to crawl')
 
     return parser.parse_args(args)
-
-
-def draw_glyph(glyph):
-    cpen = CocoaPen(glyph.getParent())
-    glyph.draw(cpen)
-    db.drawPath(cpen.path)
 
 
 def draw_anchors(glyph, size):

--- a/glyphsetProof.py
+++ b/glyphsetProof.py
@@ -22,11 +22,11 @@ import drawBot as db
 import re
 import subprocess
 
-from fontTools.pens.cocoaPen import CocoaPen
 from fontTools.pens.boundsPen import BoundsPen
 from fontTools.ttLib import TTFont
 
 from pathlib import Path
+from proofing_helpers.drawing import draw_glyph
 from proofing_helpers.files import get_ufo_paths, get_font_paths
 from proofing_helpers.globals import FONT_MONO
 from proofing_helpers.names import get_ps_name
@@ -49,17 +49,6 @@ def get_args(args=None):
         help='regex for glyph set filtering')
 
     return parser.parse_args(args)
-
-
-def draw_glyph(glyph):
-    if isinstance(glyph, defcon.objects.glyph.Glyph):
-        # UFO
-        cpen = CocoaPen(glyph.getParent())
-    else:
-        # font
-        cpen = CocoaPen(glyph.glyphSet)
-    glyph.draw(cpen)
-    db.drawPath(cpen.path)
 
 
 def get_y_bounds(glyphset):

--- a/proofing_helpers/drawing.py
+++ b/proofing_helpers/drawing.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Adobe
+# All Rights Reserved.
+
+# NOTICE: Adobe permits you to use, modify, and distribute this file in
+# accordance with the terms of the Adobe license agreement accompanying
+# it.
+
+import defcon
+import drawBot as db
+from fontParts import fontshell
+from fontTools.pens.cocoaPen import CocoaPen
+
+
+def draw_glyph(glyph):
+    '''
+    global drawing method, which allows passing either UFO- or fontTools glyphs
+    '''
+    if isinstance(
+        glyph, (defcon.objects.glyph.Glyph, fontshell.glyph.RGlyph)
+    ):
+        # UFO
+        cpen = CocoaPen(glyph.getParent())
+    else:
+        # font
+        cpen = CocoaPen(glyph.glyphSet)
+    glyph.draw(cpen)
+    db.drawPath(cpen.path)

--- a/verticalMetricsComparisonProof.py
+++ b/verticalMetricsComparisonProof.py
@@ -16,36 +16,41 @@ Input: folder containing font or UFO files.
 import defcon
 import drawBot as db
 
-from proofing_helpers import fontSorter
-from proofing_helpers.files import get_font_paths, get_ufo_paths
-from proofing_helpers.globals import FONT_MONO
-
 from verticalMetricsProof import *
 
-GLYPH_NAMES = list('Hnxphlg')
+from proofing_helpers import fontSorter
+from proofing_helpers.files import get_font_paths, get_ufo_paths
+from proofing_helpers.drawing import draw_glyph
+from proofing_helpers.globals import FONT_MONO
 
 
-def draw_metrics_page_ufo(glyph_name, font_list, page_width=1000):
-    scale_factor = PT_SIZE / 1000
+EXAMPLE_CHARS = list('Hnxphlg')
+
+
+def draw_metrics_page_ufo(character, fo_list, cmap_list, page_width=1000):
+
     db.newPage(page_width, 250)
-    x_offset = MARGIN / scale_factor
-    baseline = db.height() / 3 / scale_factor
+    x_offset = MARGIN
 
-    for font in font_list:
+    for i, font in enumerate(fo_list):
+        scale_factor = PT_SIZE / font.info.unitsPerEm
+        baseline = db.height() / 3 / scale_factor
         line_y = (
-            font.info.descender,
+            font.info.descender if font.info.descender else -250,
             0,
-            font.info.xHeight,
-            font.info.capHeight,
-            font.info.ascender
+            font.info.xHeight if font.info.xHeight else 500,
+            font.info.capHeight if font.info.capHeight else 750,
+            font.info.ascender if font.info.ascender else 750
         )
+        char_map = cmap_list[i]
+        glyph_name = char_map.get(ord(character))
         with db.savedState():
             db.scale(scale_factor)
-            db.translate(x_offset, baseline)
+            db.translate(x_offset / scale_factor, baseline)
             db.stroke(None)
             glyph = font[glyph_name]
             draw_glyph(glyph)
-            x_offset += glyph.width
+            x_offset += glyph.width * scale_factor
             with db.savedState():
                 for y_value in line_y:
                     db.stroke(0)
@@ -54,27 +59,28 @@ def draw_metrics_page_ufo(glyph_name, font_list, page_width=1000):
             with db.savedState():
                 for y_value in [v for v in line_y if v != 0]:
                     db.font(FONT_MONO)
-                    db.fontSize(30)
+                    db.fontSize(6 / scale_factor)
                     # db.fill(0, 0.981, 0.574)  # Sea Foam
                     db.fill(1, 0.186, 0.573)  # Strawberry
                     db.text(
                         str(y_value),
-                        (glyph.width / 2, y_value + 10),
+                        (glyph.width / 2, y_value + 2 / scale_factor),
                         align='center')
                 db.text(
                     font.info.styleName,
-                    (glyph.width / 2, - baseline + 20),
+                    (glyph.width / 2, -baseline + 4 / scale_factor),
                     align='center')
 
 
-def draw_metrics_page_font(glyph_name, font_info_list, page_width=1000):
+def draw_metrics_page_font(character, font_info_list, page_width=1000):
+
     db.newPage(page_width, 250)
-    upm = font_info_list[0].upm
-    scale_factor = PT_SIZE / upm
-    x_offset = MARGIN / scale_factor
-    baseline = db.height() / 3 / scale_factor
+    x_offset = MARGIN
 
     for f_info in font_info_list:
+        upm = f_info.upm
+        scale_factor = PT_SIZE / upm
+        baseline = db.height() / 3 / scale_factor
 
         line_y = (
             f_info.descender,
@@ -83,18 +89,18 @@ def draw_metrics_page_font(glyph_name, font_info_list, page_width=1000):
             f_info.capHeight,
             f_info.ascender
         )
-        character = f_info.reverse_char_map.get(glyph_name)
+        glyph_name = f_info.char_map.get(ord(character))
         with db.savedState():
             db.font(f_info.path)
             db.fontSize(f_info.upm)
             db.scale(scale_factor)
-            db.translate(x_offset, baseline)
+            db.translate(x_offset / scale_factor, baseline)
             db.text(
                 character,
                 (0, 0)
             )
             glyph_width = f_info.advance_widths[glyph_name]
-            x_offset += glyph_width
+            x_offset += glyph_width * scale_factor
             with db.savedState():
                 for y_value in line_y:
                     db.stroke(0)
@@ -103,16 +109,16 @@ def draw_metrics_page_font(glyph_name, font_info_list, page_width=1000):
             with db.savedState():
                 for y_value in [v for v in line_y if v != 0]:
                     db.font(FONT_MONO)
-                    db.fontSize(30)
+                    db.fontSize(6 / scale_factor)
                     # db.fill(0, 0.981, 0.574)  # Sea Foam
                     db.fill(1, 0.186, 0.573)  # Strawberry
                     db.text(
                         str(y_value),
-                        (glyph_width / 2, y_value + 10),
+                        (glyph_width / 2, y_value + 2 / scale_factor),
                         align='center')
                 db.text(
                     f_info.styleName,
-                    (glyph_width / 2, - baseline + 20),
+                    (glyph_width / 2, - baseline + 4 / scale_factor),
                     align='center')
 
 
@@ -138,8 +144,8 @@ def process_font_paths(font_paths, args):
             f_info.capHeight,
             f_info.ascender))
 
-    for g_name in GLYPH_NAMES:
-        draw_metrics_page_font(g_name, font_info_list, page_width)
+    for char in EXAMPLE_CHARS:
+        draw_metrics_page_font(char, font_info_list, page_width)
 
     finish_drawing(doc_name)
 
@@ -147,25 +153,39 @@ def process_font_paths(font_paths, args):
 def process_ufo_paths(ufo_paths, args):
     font_list = fontSorter.sort_fonts(ufo_paths)
     fo_list = [defcon.Font(f) for f in font_list]
+    upm_list = [f.info.unitsPerEm for f in fo_list]
+    cmap_list = [{g.unicode: g.name for g in f if g.unicode} for f in fo_list]
+    gnames_H = [cmap.get(ord('H')) for cmap in cmap_list]
+
     family_name = fo_list[0].info.familyName
     if args.output_file_name:
         doc_name = f'comparison {args.output_file_name}'
     else:
         doc_name = f'comparison {family_name} (UFO)'
+    # get combined width of Hs – no matter which glyph name or UPM they have
     page_width = sum(
-        [fo['H'].width * PT_SIZE / 1000 for fo in fo_list]
+        [fo[gnames_H[i]].width * PT_SIZE / upm_list[i] for i, fo in enumerate(fo_list)]
     ) + 2 * MARGIN
 
     for fo in fo_list:
-        print('{:20s} {:>3d} 0 {:>3d} {:>3d} {:>3d}'.format(
-            fo.info.styleName,
-            fo.info.descender,
-            fo.info.xHeight,
-            fo.info.capHeight,
-            fo.info.ascender))
+        # terminal feedback
+        format_dict = {
+            'styleName': fo.info.styleName,
+            'descender': fo.info.descender if fo.info.descender else 0,
+            'xHeight': fo.info.xHeight if fo.info.xHeight else 0,
+            'capHeight': fo.info.capHeight if fo.info.capHeight else 0,
+            'ascender': fo.info.ascender if fo.info.ascender else 0,
+        }
 
-    for g_name in GLYPH_NAMES:
-        draw_metrics_page_ufo(g_name, fo_list, page_width)
+        print('{:20s} {:>3d} 0 {:>3d} {:>3d} {:>3d}'.format(
+            format_dict.get('styleName'),
+            format_dict.get('descender'),
+            format_dict.get('xHeight'),
+            format_dict.get('capHeight'),
+            format_dict.get('ascender')))
+
+    for char in EXAMPLE_CHARS:
+        draw_metrics_page_ufo(char, fo_list, cmap_list, page_width)
 
     finish_drawing(doc_name)
 

--- a/verticalMetricsComparisonProof.py
+++ b/verticalMetricsComparisonProof.py
@@ -127,7 +127,7 @@ def process_font_paths(font_paths, args):
         doc_name = f'comparison {family_name} ({extension[1:]})'
 
     page_width = sum(
-        [fi.advance_widths['H'] * PT_SIZE / fi.upm for fi in font_info_list]
+        [fi.cap_H_width * PT_SIZE / fi.upm for fi in font_info_list]
     ) + 2 * MARGIN
 
     for f_info in font_info_list:

--- a/verticalMetricsComparisonProof.py
+++ b/verticalMetricsComparisonProof.py
@@ -16,7 +16,10 @@ Input: folder containing font or UFO files.
 import defcon
 import drawBot as db
 
-from verticalMetricsProof import *
+from verticalMetricsProof import (
+    MARGIN, PT_SIZE,
+    FontInfo,
+    finish_drawing, get_options)
 
 from proofing_helpers import fontSorter
 from proofing_helpers.files import get_font_paths, get_ufo_paths

--- a/verticalMetricsProof.py
+++ b/verticalMetricsProof.py
@@ -43,7 +43,7 @@ MARGIN_L = 6 * MARGIN
 def get_glyph_names(fi):
     # Some standard glyphs defining basic metrics,
     # as well as tallest and lowest glyphs.
-    glyph_names = list(fi.sample_string)
+    glyph_names = [fi.char_map.get(ord(char)) for char in fi.sample_string]
     glyph_names += fi.g_ymin
     glyph_names += fi.g_ymax
     return glyph_names

--- a/verticalMetricsProof.py
+++ b/verticalMetricsProof.py
@@ -26,6 +26,7 @@ from fontTools.pens.boundsPen import BoundsPen
 from fontTools import ttLib
 
 from proofing_helpers.files import get_font_paths
+from proofing_helpers.globals import FONT_MONO
 from proofing_helpers.fontSorter import sort_fonts
 from proofing_helpers.names import get_ps_name, get_name_overlap
 
@@ -221,7 +222,7 @@ def draw_metrics_page(f_info, page_width=5000):
             previous_label_baseline = -10000
             used_baselines = [previous_label_baseline]
             for line_index, (value_name, y_value) in enumerate(line_labels):
-                db.font('InputMono-Light')
+                db.font(FONT_MONO)
                 db.fontSize(30)
                 db.fill(1, 0.186, 0.573)  # Strawberry
                 v_offset = 10

--- a/verticalMetricsProof.py
+++ b/verticalMetricsProof.py
@@ -104,6 +104,7 @@ class FontInfo(object):
         self.extract_widths()
         self.extract_upm()
         self.parse_cmap()
+        self.extract_cap_H_width()
         # sTypoAscender
         # sTypoDescender
         # sxHeight
@@ -164,6 +165,11 @@ class FontInfo(object):
         self.reverse_char_map = {
             gname: chr(c_index) for c_index, gname in self.char_map.items()
         }
+
+    def extract_cap_H_width(self):
+        # do not assume the glyph name for 'H' to be 'H'
+        cap_H_gname = self.char_map.get(ord('H'), '.notdef')
+        self.cap_H_width = self.advance_widths.get(cap_H_gname)
 
 
 def draw_metrics_page(f_info, page_width=5000):

--- a/verticalMetricsProof.py
+++ b/verticalMetricsProof.py
@@ -21,10 +21,10 @@ import subprocess
 import sys
 
 import drawBot as db
-from fontTools.pens.cocoaPen import CocoaPen
 from fontTools.pens.boundsPen import BoundsPen
 from fontTools import ttLib
 
+from proofing_helpers.drawing import draw_glyph
 from proofing_helpers.files import get_font_paths
 from proofing_helpers.globals import FONT_MONO
 from proofing_helpers.fontSorter import sort_fonts
@@ -38,12 +38,6 @@ if IN_UI:
 PT_SIZE = 200
 MARGIN = 20
 MARGIN_L = 6 * MARGIN
-
-
-def draw_glyph(glyph):
-    cpen = CocoaPen(glyph.glyphSet)
-    glyph.draw(cpen)
-    db.drawPath(cpen.path)
 
 
 def get_glyph_names(fi):

--- a/verticalMetricsProof.py
+++ b/verticalMetricsProof.py
@@ -212,18 +212,20 @@ def draw_metrics_page(f_info, page_width=5000):
             for glyph_name in glyph_names])
 
         with db.savedState():
-            for value_name, y_value in line_labels:
+            # no need to draw overlapping lines twice
+            for y_value in set([value for _, value in line_labels]):
                 db.stroke(0)
                 db.strokeWidth(1)
-                db.line((-20, y_value), (string_width, y_value))
+                db.line((-4 / scale_factor, y_value), (string_width, y_value))
+
         with db.savedState():
-            line_height = 50
+            line_height = 10 / scale_factor
             # keep track of previous value for avoiding label overlap
             previous_label_baseline = -10000
             used_baselines = [previous_label_baseline]
             for line_index, (value_name, y_value) in enumerate(line_labels):
                 db.font(FONT_MONO)
-                db.fontSize(30)
+                db.fontSize(6 / scale_factor)
                 db.fill(1, 0.186, 0.573)  # Strawberry
                 v_offset = 10
                 label_baseline = y_value + v_offset
@@ -234,7 +236,9 @@ def draw_metrics_page(f_info, page_width=5000):
                         label_baseline += line_height
                     db.stroke(0)
                     db.strokeWidth(1)
-                    db.line((-30, label_baseline), (-20, y_value))
+                    db.line(
+                        (-7 / scale_factor, label_baseline),
+                        (-4 / scale_factor, y_value))
                     db.stroke(None)
 
                 if 'winDescent' in value_name:
@@ -243,7 +247,7 @@ def draw_metrics_page(f_info, page_width=5000):
                     label_value = str(y_value)
                 db.text(
                     f'{value_name}: {label_value}',
-                    (-40, label_baseline),
+                    (-8 / scale_factor, label_baseline),
                     align='right')
                 previous_label_baseline = label_baseline
                 used_baselines.append(previous_label_baseline)


### PR DESCRIPTION
This PR is mainly about the labels in the vertical metrics proofs:
* the point size of metrics labels is no longer dependent on the UPM of a given font/UFO
* metrics labels can be converted to their 1000-UPM equivalent

Along the way, I fixed some more issues I encountered:
* do not assume fonts to have specific standard glyph names (such as `H`)
* do not assume all fonts to have the same UPM

Cosmetics:
* glyph drawing has been moved to its own module. It is accessed by lots of scripts, so no need for code duplication.
* remove hard-coded call to InputMono